### PR TITLE
Unblock broken eclipse plugin

### DIFF
--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/preferences/ContrastPreferencesPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/preferences/ContrastPreferencesPage.java
@@ -67,7 +67,7 @@ import com.contrastsecurity.sdk.ContrastSDK;
 public class ContrastPreferencesPage extends PreferencePage implements IWorkbenchPreferencePage {
 
 	public static final String ID = "com.contrastsecurity.ide.eclipse.ui.internal.preferences.ContrastPreferencesPage";
-	private final static String URL_SUFFIX = "/Contrast/api";
+	private final static String URL_SUFFIX = "/Contrast";
 	private Text teamServerText;
 	private Text usernameText;
 	private Text serviceKeyText;
@@ -169,7 +169,7 @@ public class ContrastPreferencesPage extends PreferencePage implements IWorkbenc
 
 			@Override
 			public void widgetSelected(SelectionEvent arg0) {
-				verifyTeamServerUrl();
+				//verifyTeamServerUrl();
 				retrieveOrganizationName(composite);
 			}
 


### PR DESCRIPTION
User enters URL:

```
https://app.contrastsecurity.com/Contrast
```

but Eclipse plugin automatically updates user input to:

```
https://app.contrastsecurity.com/Contrast/api
```

resulting in error

![image (210)](https://user-images.githubusercontent.com/681555/130604738-8b53a523-6ef7-4db0-84f3-b194ef223e50.png)

The gradle plugin and basic java classpath configuration works correctly without the /api suffix.