### PR TITLE
TS-16457 modify the eclipse plugin publish action workflow to sign the artifacts before upload to the update site

### DIFF
--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -9,10 +9,10 @@ jobs:
         name: Build, Sign and Publish
         runs-on: ubuntu-latest
         permissions: 
-            contents: read|write
-            deployments: read|write
+            contents: read,write
+            deployments: write
             checks: read
-            packages: read|write
+            packages: write
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -30,8 +30,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PFX_CODE: ${{ secrets.PFX_CODE }}
               run: mvn unleash:perform-tycho -B -Dunleash.releaseArgs="skipTests=true, keystore.path=${HOME}/keystore_file, keystore.storepass='$PFX_CODE', keystore.alias=1, keystore.keypass='$PFX_CODE'" -Dunleash.versionUpgradeStrategy=DEFAULT -Dworkflow=customWorkflow -Dunleash.scmUsername=$GITHUB_ACTOR -Dunleash.scmPassword=$GITHUB_TOKEN
-            -name Clean up signing
+            - name: Clean up signing
               continue-on-error: true
-              run |
+              run: |
                 rm -f ${HOME}/keystore_file
                 exit 1

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -5,8 +5,8 @@ on:
     workflow_dispatch:
 
 jobs:
-    name: Build, Sign and Publish
     build:
+        name: Build, Sign and Publish
         runs-on: ubuntu-latest
         permissions: write-all
         steps:

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Write key file
         env:
-          CODE_SIGN_PFX: ${{ secrets.PFX_CERT_SIGN }}
+          CODE_SIGN_PFX: ${{ secrets.CODE_SIGN_PFX }}
           PFX_CODE: ${{ secrets.PFX_CODE }}
         run: |
           echo "$CODE_SIGN_PFX" | base64 --decode > ${HOME}/key.pfx

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -8,7 +8,10 @@ jobs:
     build:
         name: Build, Sign and Publish
         runs-on: ubuntu-latest
-        permissions: write-all
+        permissions: 
+            contents: read
+            deployments: write
+            checks: read
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -9,9 +9,10 @@ jobs:
         name: Build, Sign and Publish
         runs-on: ubuntu-latest
         permissions: 
-            contents: read
-            deployments: write
+            contents: read|write
+            deployments: read|write
             checks: read
+            packages: read|write
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -2,31 +2,38 @@
 
 name: PFX To File
 
-# Controls when the workflow will run
 on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-      - name: Write key file
-        env:
-          CODE_SIGN_PFX: ${{ secrets.CODE_SIGN_PFX }}
-          PFX_CODE: ${{ secrets.PFX_CODE }}
-        run: |
-          echo "$CODE_SIGN_PFX" | base64 --decode > ${HOME}/key.pfx
-          keytool -importkeystore -srckeystore ${HOME}/key.pfx -srcstoretype pkcs12 -destkeystore contrast-code-sign-cert.jks -deststoretype pkcs12 -deststorepass "$PFX_CODE" -srcstorepass "$PFX_CODE" -keystore ${HOME}/keystore_file -v
-          cd ${HOME}
-          pwd
-          ls -la
-          mvn verify -DskipTests=true -Dmaven.javadoc.skip=true -Dkeystore.path=${HOME}/keystore_file -Dkeystore.storepass="$PFX_CODE" -Dkeystore.alias=1 -Dkeystore.keypass="$PFX_CODE" -B -V -e
-          rm -f {HOME}/keystore_file
+    build:
+        runs-on: ubuntu-latest
+        permissions: write-all
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - name: Set up JDK 8
+              uses: actions/setup-java@v2
+              with:
+                  java-version: "8"
+                  distribution: "adopt"
+                  server-id: "ossrh"
+            - name: Prepare for signing
+              env:
+                CODE_SIGN_PFX: ${{ secrets.CODE_SIGN_PFX }}
+                PFX_CODE: ${{ secrets.PFX_CODE }}
+              run: |
+                echo "$CODE_SIGN_PFX" | base64 --decode > ${HOME}/key.pfx
+                keytool -importkeystore -srckeystore ${HOME}/key.pfx -srcstoretype pkcs12 -destkeystore contrast-code-sign-cert.jks -deststoretype pkcs12 -deststorepass "$PFX_CODE" -srcstorepass "$PFX_CODE" -keystore ${HOME}/keystore_file
+            - name: Bump Version and Build Artifact
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PFX_CODE: ${{ secrets.PFX_CODE }}
+              run: mvn unleash:perform-tycho -B -Dunleash.releaseArgs="skipTests=true, keystore.path=${HOME}/keystore_file, keystore.storepass='$PFX_CODE', keystore.alias=1, keystore.keypass='$PFX_CODE'" -Dunleash.versionUpgradeStrategy=DEFAULT -Dworkflow=customWorkflow -Dunleash.scmUsername=$GITHUB_ACTOR -Dunleash.scmPassword=$GITHUB_TOKEN
+            -name Clean up signing
+              continue-on-error: true
+              run |
+                rm -f ${HOME}/keystore_file
+                exit 1
+                

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -19,4 +19,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Write key file
+        env:
+          CODE_SIGN_PFX: ${{ secrets.PFX_CERT_SIGN }}
+          PFX_CODE: ${{ secrets.PFX_CODE }}
+        run: |
+          echo "$CODE_SIGN_PFX" | base64 --decode > ${HOME}/key.pfx
+          keytool -importkeystore -srckeystore ${HOME}/key.pfx -srcstoretype pkcs12 -destkeystore contrast-code-sign-cert.jks -deststoretype pkcs12 -deststorepass "$PFX_CODE" -srcstorepass "$PFX_CODE" -keystore ${HOME}/keystore_file -v
+          cd ${HOME}
+          pwd
           ls -la
+          mvn verify -DskipTests=true -Dmaven.javadoc.skip=true -Dkeystore.path=${HOME}/keystore_file -Dkeystore.storepass="$PFX_CODE" -Dkeystore.alias=1 -Dkeystore.keypass="$PFX_CODE" -B -V -e
+          rm -f {HOME}/keystore_file

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -35,3 +35,10 @@ jobs:
               run: |
                 rm -f ${HOME}/keystore_file
                 rm -f ${HOME}/key.pfx
+            - name: Artifacts
+              uses: actions/upload-artifact@v2
+              with:
+                name: plugins artifacts
+                path: ./updatesite/target/repository/plugins
+                name: features artifacts
+                path: ./updatesite/target/repository/features

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -39,6 +39,4 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                 name: plugins artifacts
-                path: ./updatesite/target/repository/plugins
-                name: features artifacts
-                path: ./updatesite/target/repository/features
+                path: ./updatesite/target/repository

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -9,7 +9,7 @@ jobs:
         name: Build, Sign and Publish
         runs-on: ubuntu-latest
         permissions: 
-            contents: read,write
+            contents: write
             deployments: write
             checks: read
             packages: write

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
 
 jobs:
-  - name: Build, Sign and Publish
+    name: Build, Sign and Publish
     build:
         runs-on: ubuntu-latest
         permissions: write-all

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -5,18 +5,19 @@ on:
     workflow_dispatch:
 
 jobs:
+  - name: Build, Sign and Publish
     build:
         runs-on: ubuntu-latest
         permissions: write-all
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - name: Set up JDK 8
-              uses: actions/setup-java@v2
+              uses: actions/setup-java@v3
               with:
                   java-version: "8"
-                  distribution: "adopt"
+                  distribution: "temurin"
                   server-id: "ossrh"
             - name: Prepare for signing
               env:
@@ -31,12 +32,13 @@ jobs:
                   PFX_CODE: ${{ secrets.PFX_CODE }}
               run: mvn unleash:perform-tycho -B -Dunleash.releaseArgs="skipTests=true, keystore.path=${HOME}/keystore_file, keystore.storepass='$PFX_CODE', keystore.alias=1, keystore.keypass='$PFX_CODE'" -Dunleash.versionUpgradeStrategy=DEFAULT -Dworkflow=customWorkflow -Dunleash.scmUsername=$GITHUB_ACTOR -Dunleash.scmPassword=$GITHUB_TOKEN
             - name: Clean up signing
+              if: always()
               continue-on-error: true
               run: |
                 rm -f ${HOME}/keystore_file
                 rm -f ${HOME}/key.pfx
             - name: Artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                 name: plugins artifacts
                 path: ./updatesite/target/repository

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -1,5 +1,4 @@
 # Workflow to test secrets, first version empty in order to be able to run it from branch
-
 name: PFX To File
 
 on:
@@ -36,4 +35,3 @@ jobs:
               run |
                 rm -f ${HOME}/keystore_file
                 exit 1
-                

--- a/.github/workflows/pfx_to_file.yml
+++ b/.github/workflows/pfx_to_file.yml
@@ -34,4 +34,4 @@ jobs:
               continue-on-error: true
               run: |
                 rm -f ${HOME}/keystore_file
-                exit 1
+                rm -f ${HOME}/key.pfx

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,11 @@ jobs:
     build:
         name: Build, Sign and Publish
         runs-on: ubuntu-latest
-        permissions: write-all
+        permissions: 
+            contents: write
+            deployments: write
+            checks: read
+            packages: write
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,23 @@ jobs:
                   java-version: "8"
                   distribution: "adopt"
                   server-id: "ossrh"
+            - name: Prepare for signing
+              env:
+                CODE_SIGN_PFX: ${{ secrets.CODE_SIGN_PFX }}
+                PFX_CODE: ${{ secrets.PFX_CODE }}
+              run: |
+                echo "$CODE_SIGN_PFX" | base64 --decode > ${HOME}/key.pfx
+                keytool -importkeystore -srckeystore ${HOME}/key.pfx -srcstoretype pkcs12 -destkeystore contrast-code-sign-cert.jks -deststoretype pkcs12 -deststorepass "$PFX_CODE" -srcstorepass "$PFX_CODE" -keystore ${HOME}/keystore_file
             - name: Bump Version and Build Artifact
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: mvn unleash:perform-tycho -B -Dunleash.releaseArgs="jarsigner.skip=true, skipTests=true" -Dunleash.versionUpgradeStrategy=DEFAULT -Dworkflow=customWorkflow -Dunleash.scmUsername=$GITHUB_ACTOR -Dunleash.scmPassword=$GITHUB_TOKEN
+                  PFX_CODE: ${{ secrets.PFX_CODE }}
+              run: mvn unleash:perform-tycho -B -Dunleash.releaseArgs="skipTests=true, keystore.path=${HOME}/keystore_file, keystore.storepass='$PFX_CODE', keystore.alias=1, keystore.keypass='$PFX_CODE'" -Dunleash.versionUpgradeStrategy=DEFAULT -Dworkflow=customWorkflow -Dunleash.scmUsername=$GITHUB_ACTOR -Dunleash.scmPassword=$GITHUB_TOKEN
+            - name: Clean up signing
+              continue-on-error: true
+              run: |
+                rm -f ${HOME}/keystore_file
+                rm -f ${HOME}/key.pfx
             - name: Configure AWS Credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,17 +5,18 @@ on:
 
 jobs:
     build:
+        name: Build, Sign and Publish
         runs-on: ubuntu-latest
         permissions: write-all
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - name: Set up JDK 8
-              uses: actions/setup-java@v2
+              uses: actions/setup-java@v3
               with:
                   java-version: "8"
-                  distribution: "adopt"
+                  distribution: "temurin"
                   server-id: "ossrh"
             - name: Prepare for signing
               env:
@@ -30,6 +31,7 @@ jobs:
                   PFX_CODE: ${{ secrets.PFX_CODE }}
               run: mvn unleash:perform-tycho -B -Dunleash.releaseArgs="skipTests=true, keystore.path=${HOME}/keystore_file, keystore.storepass='$PFX_CODE', keystore.alias=1, keystore.keypass='$PFX_CODE'" -Dunleash.versionUpgradeStrategy=DEFAULT -Dworkflow=customWorkflow -Dunleash.scmUsername=$GITHUB_ACTOR -Dunleash.scmPassword=$GITHUB_TOKEN
             - name: Clean up signing
+              if: always()
               continue-on-error: true
               run: |
                 rm -f ${HOME}/keystore_file

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.5.qualifier"
+      version="3.0.6.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.12.qualifier"
+      version="3.0.13.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.9.qualifier"
+      version="3.0.10.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.16.qualifier"
+      version="3.0.17.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.10.qualifier"
+      version="3.0.11.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.7.qualifier"
+      version="3.0.8.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.6.qualifier"
+      version="3.0.7.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.8.qualifier"
+      version="3.0.9.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.15.qualifier"
+      version="3.0.16.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.13.qualifier"
+      version="3.0.14.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.14.qualifier"
+      version="3.0.15.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.contrastsecurity.ide.eclipse.feature"
       label="%FEATURE_NAME"
-      version="3.0.11.qualifier"
+      version="3.0.12.qualifier"
       provider-name="%PROVIDER_NAME"
       plugin="com.contrastsecurity.ide.eclipse.core">
    <description>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
+++ b/features/com.contrastsecurity.ide.eclipse.feature/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.5.qualifier
+Bundle-Version: 3.0.6.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.11.qualifier
+Bundle-Version: 3.0.12.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.16.qualifier
+Bundle-Version: 3.0.17.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.6.qualifier
+Bundle-Version: 3.0.7.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.13.qualifier
+Bundle-Version: 3.0.14.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.7.qualifier
+Bundle-Version: 3.0.8.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.9.qualifier
+Bundle-Version: 3.0.10.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.12.qualifier
+Bundle-Version: 3.0.13.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.15.qualifier
+Bundle-Version: 3.0.16.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.10.qualifier
+Bundle-Version: 3.0.11.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.14.qualifier
+Bundle-Version: 3.0.15.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core.tests
-Bundle-Version: 3.0.8.qualifier
+Bundle-Version: 3.0.9.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.core;bundle-version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  com.contrastsecurity.ide.eclipse.core

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.13.qualifier
+Bundle-Version: 3.0.14.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.8.qualifier
+Bundle-Version: 3.0.9.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.5.qualifier
+Bundle-Version: 3.0.6.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.6.qualifier
+Bundle-Version: 3.0.7.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.7.qualifier
+Bundle-Version: 3.0.8.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.9.qualifier
+Bundle-Version: 3.0.10.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.14.qualifier
+Bundle-Version: 3.0.15.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.11.qualifier
+Bundle-Version: 3.0.12.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.16.qualifier
+Bundle-Version: 3.0.17.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.12.qualifier
+Bundle-Version: 3.0.13.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.15.qualifier
+Bundle-Version: 3.0.16.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.core;singleton:=true
-Bundle-Version: 3.0.10.qualifier
+Bundle-Version: 3.0.11.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.core</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.5.qualifier
+Bundle-Version: 3.0.6.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.9.qualifier
+Bundle-Version: 3.0.10.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.6.qualifier
+Bundle-Version: 3.0.7.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.10.qualifier
+Bundle-Version: 3.0.11.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.8.qualifier
+Bundle-Version: 3.0.9.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.7.qualifier
+Bundle-Version: 3.0.8.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.16.qualifier
+Bundle-Version: 3.0.17.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.13.qualifier
+Bundle-Version: 3.0.14.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.14.qualifier
+Bundle-Version: 3.0.15.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.12.qualifier
+Bundle-Version: 3.0.13.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.11.qualifier
+Bundle-Version: 3.0.12.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui.tests
-Bundle-Version: 3.0.15.qualifier
+Bundle-Version: 3.0.16.qualifier
 Fragment-Host: com.contrastsecurity.ide.eclipse.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui.tests/pom.xml
@@ -18,6 +18,6 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.5.qualifier
+Bundle-Version: 3.0.6.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.15.qualifier
+Bundle-Version: 3.0.16.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.11.qualifier
+Bundle-Version: 3.0.12.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.7.qualifier
+Bundle-Version: 3.0.8.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.8.qualifier
+Bundle-Version: 3.0.9.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.14.qualifier
+Bundle-Version: 3.0.15.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.13.qualifier
+Bundle-Version: 3.0.14.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.16.qualifier
+Bundle-Version: 3.0.17.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.9.qualifier
+Bundle-Version: 3.0.10.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.10.qualifier
+Bundle-Version: 3.0.11.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.6.qualifier
+Bundle-Version: 3.0.7.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Localization: OSGI-INF/l10n/bundle
 Bundle-SymbolicName: com.contrastsecurity.ide.eclipse.ui;singleton:=true
-Bundle-Version: 3.0.12.qualifier
+Bundle-Version: 3.0.13.qualifier
 Bundle-Activator: com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.eclipse.ui</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.5.qualifier
+Bundle-Version: 3.0.6.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.11.qualifier
+Bundle-Version: 3.0.12.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.15.qualifier
+Bundle-Version: 3.0.16.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.13.qualifier
+Bundle-Version: 3.0.14.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.14.qualifier
+Bundle-Version: 3.0.15.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.9.qualifier
+Bundle-Version: 3.0.10.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.8.qualifier
+Bundle-Version: 3.0.9.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.6.qualifier
+Bundle-Version: 3.0.7.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.16.qualifier
+Bundle-Version: 3.0.17.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.12.qualifier
+Bundle-Version: 3.0.13.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.10.qualifier
+Bundle-Version: 3.0.11.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contrast Security
 Bundle-SymbolicName: com.contrastsecurity.ide.rest.sdk
-Bundle-Version: 3.0.7.qualifier
+Bundle-Version: 3.0.8.qualifier
 Bundle-Vendor: Contrast REST API SDK
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.gson;visibility:=reexport,

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
+++ b/plugins/com.contrastsecurity.ide.rest.sdk/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse.plugins</groupId>
 	<artifactId>com.contrastsecurity.ide.rest.sdk</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.5-SNAPSHOT</version>
+	<version>3.0.6-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.8-SNAPSHOT</version>
+	<version>3.0.9-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.16-SNAPSHOT</version>
+	<version>3.0.17-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.9-SNAPSHOT</version>
+	<version>3.0.10-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.10-SNAPSHOT</version>
+	<version>3.0.11-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.13-SNAPSHOT</version>
+	<version>3.0.14-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.11-SNAPSHOT</version>
+	<version>3.0.12-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.15-SNAPSHOT</version>
+	<version>3.0.16-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.14-SNAPSHOT</version>
+	<version>3.0.15-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.6-SNAPSHOT</version>
+	<version>3.0.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.7-SNAPSHOT</version>
+	<version>3.0.8-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.0.12-SNAPSHOT</version>
+	<version>3.0.13-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.5.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.5.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.6.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.6.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.15.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.15.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.16.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.16.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.9.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.9.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.10.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.10.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.10.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.10.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.11.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.11.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.16.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.16.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.17.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.17.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.7.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.7.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.8.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.8.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.13.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.13.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.14.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.14.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.11.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.11.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.12.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.12.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.14.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.14.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.15.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.15.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.8.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.8.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.9.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.9.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.6.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.6.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.7.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.7.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -3,7 +3,7 @@
    <description>
       Contrast Security Update Site
    </description>
-   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.12.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.12.qualifier">
+   <feature url="features/com.contrastsecurity.ide.eclipse.feature_3.0.13.qualifier.jar" id="com.contrastsecurity.ide.eclipse.feature" version="3.0.13.qualifier">
       <category name="com.contrastsecurity.ide.eclipse"/>
    </feature>
    <category-def name="com.contrastsecurity.ide.eclipse" label="Contrast IDE">

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.5-SNAPSHOT</version>
+		<version>3.0.6-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.7-SNAPSHOT</version>
+		<version>3.0.8-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.11-SNAPSHOT</version>
+		<version>3.0.12-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.16-SNAPSHOT</version>
+		<version>3.0.17-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.6-SNAPSHOT</version>
+		<version>3.0.7-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.10-SNAPSHOT</version>
+		<version>3.0.11-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.13-SNAPSHOT</version>
+		<version>3.0.14-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.8-SNAPSHOT</version>
+		<version>3.0.9-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.12-SNAPSHOT</version>
+		<version>3.0.13-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.15-SNAPSHOT</version>
+		<version>3.0.16-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.14-SNAPSHOT</version>
+		<version>3.0.15-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.contrastsecurity.ide.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.0.9-SNAPSHOT</version>
+		<version>3.0.10-SNAPSHOT</version>
 	</parent>
 	<groupId>com.contrastsecurity.ide.eclipse</groupId>
 	<artifactId>contrastide.updatesite</artifactId>


### PR DESCRIPTION
Changes:
publish.yml 
pfx_to_file.yml

Motivation:

- the publish action which updates the plugin jars to the eclipse update site now sign the jar files to avoid the warning message when the eclipse plug-in is downloaded.
- Because this change affects directly the files downloaded by clients was created a similar action to allow the reviewes test and verify the signing

How To Test:

- Run the PFX to File action over this branch.
- When the workflow finish download the artifacts created (link at the bottom)
- Using jarsigner run on a command window: jarsigner -verify file_to_verifiy.jar on the plugins and features jars

